### PR TITLE
AsCommand attribute

### DIFF
--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -5,11 +5,16 @@ namespace Portiny\RabbitMQ\Command;
 use Bunny\Channel;
 use Portiny\RabbitMQ\BunnyManager;
 use Portiny\RabbitMQ\Consumer\AbstractConsumer;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'rabbitmq:consume',
+    description: 'Run a RabbitMQ consumer'
+)]
 final class ConsumeCommand extends Command
 {
 

--- a/src/Command/DeclareCommand.php
+++ b/src/Command/DeclareCommand.php
@@ -3,10 +3,15 @@
 namespace Portiny\RabbitMQ\Command;
 
 use Portiny\RabbitMQ\BunnyManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'rabbitmq:declare',
+    description: 'Creates all exchanges and queues.'
+)]
 final class DeclareCommand extends Command
 {
 


### PR DESCRIPTION
Fix error `Command "Portiny\RabbitMQ\Command\DeclareCommand" missing #[AsCommand] attribute`.